### PR TITLE
Add SWPR Token Convertor

### DIFF
--- a/contracts/SWPRConvertor.sol
+++ b/contracts/SWPRConvertor.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./SWPR.sol";
 
 error ZeroAddressInput();
@@ -17,7 +18,7 @@ error InconsistentArrayLengths();
  * @author Augusto Lemble - <augustolemble@pm.me>
  * SPDX-License-Identifier: GPL-3.0
  */
-contract SWPRConvertor is Ownable {
+contract SWPRConvertor is Ownable, ReentrancyGuard {
 
     address public swprTokenA;
     address public swprTokenB;
@@ -30,7 +31,7 @@ contract SWPRConvertor is Ownable {
     }
 
     // Burn allowed SWPRTokenA to this SWPRConvertor and transfer SWPRTokenB to the account
-    function convert(address account) external {
+    function convert(address account) nonReentrant external {
         
         // Check that the account has SWPRTokenA balance
         uint256 swprTokenABalance = SWPR(swprTokenA).balanceOf(account);

--- a/contracts/SWPRConvertor.sol
+++ b/contracts/SWPRConvertor.sol
@@ -1,0 +1,71 @@
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+error ZeroAddressInput();
+error InconsistentArrayLengths();
+
+/**
+ * @title SWPRConvertor
+ * @dev SWPRConvertor contract
+ * Smart contracts to convert SWPRTokenA to SWPRTokenB using a 1:1 ratio.
+ * Convertion steps:
+ * 1.- The user needs to approve all his SWPRTokenA to the SWPRConvertor contract.
+ * 2.- The SWPRConvertor contract is called to execute the convertion of tokens.
+      SWPRTokenA is burned and the same amount in SWPRTokenB is sent to the user.
+ * @author Augusto Lemble - <augustolemble@pm.me>
+ * SPDX-License-Identifier: GPL-3.0
+ */
+contract SWPRConvertor is Ownable {
+    using SafeERC20 for IERC20;
+
+    address public swprTokenA;
+    address public swprTokenB;
+
+    constructor(address _swprTokenA, address _swprTokenB) {
+        if (_swprTokenA == address(0)) revert ZeroAddressInput();
+        if (_swprTokenB == address(0)) revert ZeroAddressInput();
+        swprTokenA = _swprTokenA;
+        swprTokenB = _swprTokenB;
+    }
+
+    // Burn allowed SWPRTokenA to this SWPRConvertor and transfer SWPRTokenB to the account
+    function convert(address account) external {
+        uint256 swprTokenAAllowance = IERC20(swprTokenA).allowance(account, address(this));
+        uint256 swprTokenABalance = IERC20(swprTokenA).balanceOf(account);
+        
+        // Check that the SWPRTokenA allowance is enough to do the convertion
+        require(
+          swprTokenAAllowance > 0,
+          "SWPRConvertor: SWPRTokenA allowance is 0"
+          );
+        require(
+          swprTokenABalance > 0,
+          "SWPRConvertor: SWPRTokenA balance is 0"
+        );
+        require(
+          swprTokenAAllowance >= swprTokenABalance,
+          "SWPRConvertor: SWPRTokenA allowance is not enough"
+        );
+        
+        // Burn SWPRTokenA by sending them to address(1)
+        IERC20(swprTokenA).safeTransferFrom(
+            account,
+            address(1),
+            swprTokenABalance
+        );
+        
+        // Transfer the SWPRTokenB to the account
+        IERC20(swprTokenB).safeTransfer(account, swprTokenABalance);
+    }
+
+    // Transfer the SWPRTokenB balance from the SWPRConvertor to the owner
+    function recover() external {
+        IERC20(swprTokenB).safeTransfer(
+            owner(),
+            IERC20(swprTokenB).balanceOf(address(this))
+        );
+    }
+}

--- a/contracts/SWPRConvertor.sol
+++ b/contracts/SWPRConvertor.sol
@@ -47,12 +47,10 @@ contract SWPRConvertor is Ownable {
         );
         
         // Burn SWPRTokenA
-        SWPR(swprTokenA).transferFrom(
+        SWPR(swprTokenA).burnFrom(
             account,
-            address(this),
             swprTokenABalance
         );
-        SWPR(swprTokenA).burn(swprTokenABalance);
         
         // Transfer the SWPRTokenB to the account
         SWPR(swprTokenB).transfer(account, swprTokenABalance);

--- a/contracts/SWPRConvertor.sol
+++ b/contracts/SWPRConvertor.sol
@@ -33,18 +33,16 @@ contract SWPRConvertor is Ownable {
 
     // Burn allowed SWPRTokenA to this SWPRConvertor and transfer SWPRTokenB to the account
     function convert(address account) external {
-        uint256 swprTokenAAllowance = IERC20(swprTokenA).allowance(account, address(this));
-        uint256 swprTokenABalance = IERC20(swprTokenA).balanceOf(account);
         
-        // Check that the SWPRTokenA allowance is enough to do the convertion
-        require(
-          swprTokenAAllowance > 0,
-          "SWPRConvertor: SWPRTokenA allowance is 0"
-          );
+        // Check that the account has SWPRTokenA balance
+        uint256 swprTokenABalance = IERC20(swprTokenA).balanceOf(account);
         require(
           swprTokenABalance > 0,
           "SWPRConvertor: SWPRTokenA balance is 0"
         );
+
+        // Check that the SWPRTokenA allowance is enough to do the convertion
+        uint256 swprTokenAAllowance = IERC20(swprTokenA).allowance(account, address(this));
         require(
           swprTokenAAllowance >= swprTokenABalance,
           "SWPRConvertor: SWPRTokenA allowance is not enough"

--- a/contracts/SWPRConvertor.sol
+++ b/contracts/SWPRConvertor.sol
@@ -39,13 +39,6 @@ contract SWPRConvertor is Ownable {
           "SWPRConvertor: SWPRTokenA balance is 0"
         );
 
-        // Check that the SWPRTokenA allowance is enough to do the convertion
-        uint256 swprTokenAAllowance = SWPR(swprTokenA).allowance(account, address(this));
-        require(
-          swprTokenAAllowance >= swprTokenABalance,
-          "SWPRConvertor: SWPRTokenA allowance is not enough"
-        );
-        
         // Burn SWPRTokenA
         SWPR(swprTokenA).burnFrom(
             account,

--- a/test/convertor/index.test.ts
+++ b/test/convertor/index.test.ts
@@ -94,10 +94,17 @@ describe("SWPRConvertor", () => {
           swprConvertor.connect(initialHolderAccountB).convert(noTokenHolder.address)
         ).to.be.revertedWith("SWPRConvertor: SWPRTokenA balance is 0");
 
+        const swprATotalSupplyBeforeConvert = await swprA.totalSupply();
+
         // Do the right allowance and convert
         await swprA.connect(claimerAccount).approve(swprConvertor.address, "100");
         await swprConvertor.connect(initialHolderAccountB).convert(claimerAccount.address);
         expect(await swprB.balanceOf(swprConvertor.address)).to.be.equal("900");
+        
+        // Check that SWPRTokenA was burned
+        expect(await swprA.totalSupply()).to.be.equal(
+            BigNumber.from(swprATotalSupplyBeforeConvert).sub(100)
+        );
 
         // Check final balance of claimer
         expect(await swprA.balanceOf(claimerAccount.address)).to.be.equal("0");

--- a/test/convertor/index.test.ts
+++ b/test/convertor/index.test.ts
@@ -80,13 +80,13 @@ describe("SWPRConvertor", () => {
         // No allowance done
         await expect(
             swprConvertor.connect(initialHolderAccountB).convert(claimerAccount.address)
-        ).to.be.revertedWith("SWPRConvertor: SWPRTokenA allowance is not enough");
+        ).to.be.revertedWith("ERC20: burn amount exceeds allowance");
         
         // Not enough allowance
         await swprA.connect(claimerAccount).approve(swprConvertor.address, "90");
         await expect(
             swprConvertor.connect(initialHolderAccountB).convert(claimerAccount.address)
-        ).to.be.revertedWith("SWPRConvertor: SWPRTokenA allowance is not enough");
+        ).to.be.revertedWith("ERC20: burn amount exceeds allowance");
         
         // Not SWPRTokenA holder
         const noTokenHolder = wallets[7];

--- a/test/convertor/index.test.ts
+++ b/test/convertor/index.test.ts
@@ -1,0 +1,89 @@
+import { expect, use } from "chai";
+import { formatBytes32String } from "ethers/lib/utils";
+import { waffle } from "hardhat";
+import { BigNumber, constants, Wallet } from "ethers";
+import { fixture, fixtureOnlyToken } from "../fixtures";
+import { deployContract } from "ethereum-waffle";
+import { SWPRClaimer } from "../../typechain";
+import { SWPRConvertor } from "../../typechain";
+import swprClaimerJson from "../../artifacts/contracts/SWPRClaimer.sol/SWPRClaimer.json";
+import swprConvertorJson from "../../artifacts/contracts/SWPRConvertor.sol/SWPRConvertor.json";
+import { MerkleTree } from "../../merkle-tree";
+import { fastForwardTo } from "../utils";
+
+const { solidity, loadFixture } = waffle;
+use(solidity);
+
+describe("SWPRConvertor", () => {
+
+    it("should succeed converting", async () => {
+        const timeLimit = Math.floor(Date.now() / 1000) + 1000;
+
+        const { initialHolderAccount: initialHolderAccountA, claimerAccount, swpr: swprA } =
+            await loadFixture(fixture);
+        const claimerAddress = await claimerAccount.getAddress();
+        const leaves = [
+            { account: claimerAddress, amount: "100" },
+            { account: Wallet.createRandom().address, amount: "200" },
+            { account: Wallet.createRandom().address, amount: "300" },
+            { account: Wallet.createRandom().address, amount: "500" },
+        ];
+        const tree = new MerkleTree(leaves);
+
+        // deploying claimer
+        const wallets = await waffle.provider.getWallets();
+        const owner = wallets[6]; // random, new owner
+        const swprClaimer = (await deployContract(owner, swprClaimerJson, [
+            swprA.address,
+            tree.root,
+            timeLimit,
+        ])) as unknown as SWPRClaimer;
+
+        // funding claimer
+        const initialClaimerFunding = "1100";
+        await swprA
+            .connect(initialHolderAccountA)
+            .transfer(swprClaimer.address, initialClaimerFunding);
+
+        expect(await swprA.balanceOf(claimerAddress)).to.be.equal(0);
+        expect(await swprA.balanceOf(swprClaimer.address)).to.be.equal(
+            initialClaimerFunding
+        );
+
+        // performing the claim
+        await swprClaimer
+            .connect(claimerAccount)
+            .claim(leaves[0].amount, tree.getProof(leaves[0]));
+
+        await fastForwardTo(timeLimit + 10);
+        expect(await swprA.balanceOf(owner.address)).to.be.equal(0);
+        await swprClaimer.recover();
+        expect(await swprA.balanceOf(owner.address)).to.be.equal(
+            BigNumber.from(initialClaimerFunding).sub(100) // 100 was claimed
+        );
+        
+        expect(await swprA.balanceOf(claimerAccount.address)).to.be.equal("100");
+        
+        // deploy SWPRTokenB
+        const { initialHolderAccount: initialHolderAccountB, swpr: swprB } =
+            await loadFixture(fixtureOnlyToken);
+        
+        // deploy convertor
+        const swprConvertor = (await deployContract(owner, swprConvertorJson, [
+            swprA.address,
+            swprB.address
+        ])) as unknown as SWPRConvertor;
+        
+        await swprB.connect(initialHolderAccountB).transfer(swprConvertor.address, "1000");
+        expect(await swprB.balanceOf(swprConvertor.address)).to.be.equal("1000");
+
+        await swprA.connect(claimerAccount).approve(swprConvertor.address, "100");
+        
+        await swprConvertor.connect(initialHolderAccountB).convert(claimerAccount.address);
+        expect(await swprB.balanceOf(swprConvertor.address)).to.be.equal("900");
+
+        // Check final balance of claimer
+        expect(await swprA.balanceOf(claimerAccount.address)).to.be.equal("0");
+        expect(await swprB.balanceOf(claimerAccount.address)).to.be.equal("100");
+    });
+});

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -15,3 +15,16 @@ export const fixture = async (_: any, provider: MockProvider) => {
         claimerAccount,
     };
 };
+
+export const fixtureOnlyToken = async (_: any, provider: MockProvider) => {
+    const initialHolderAccount = provider.getWallets()[9];
+
+    const swpr = (await deployContract(initialHolderAccount, swprJson, [
+        initialHolderAccount.address,
+    ])) as unknown as SWPR;
+
+    return {
+        swpr,
+        initialHolderAccount,
+    };
+};


### PR DESCRIPTION
This PR adds the SWPRConverter smart contract. 

The SWPRConverter is deployed with two SWPR token address, SWPRTokenA and SWPRTokenB.

Once deployed SWPRTokenB tokens need to be sent to the converter.

Once the converter contract has SWPRTokenB tokens it can start converting SWPRTokenA to SWPRTokenB.

To convert tokens a user needs to approve his entire balance of SWPRTokenA to the converter contract.

Once the SWPRTokenA is approved the convert function can be called by the user or any other address.

In the convert function the SWPRTokenA will be transfered to the convertor contract and burned, the user will receive the same amount of tokens in SWPRTokenB.